### PR TITLE
Tensions view — two-axis trade-off explorer

### DIFF
--- a/comparison-tool/app.js
+++ b/comparison-tool/app.js
@@ -234,7 +234,220 @@
       render();
     });
 
+    setupViews();
+    initTensions();
     render();
+  }
+
+  // ===== Tensions view (scatter + Pareto frontier + insight) ================
+  var PLOT_AXES = ["ambientLight", "scale", "resolution", "motion", "transparency",
+                   "color", "dimensionality", "availability", "cost", "safety"];
+  var PRESETS = {
+    bigsharp: { x: "resolution",    y: "scale",        fx: false, fy: false,
+      cap: "Here “resolution” means perceived sharpness / pixel density up close. Fine-pitch LED (≈0.7 mm) is narrowing this at scale, but most large formats still trade fine detail for size." },
+    bright:   { x: "ambientLight",  y: "transparency", fx: false, fy: false,
+      cap: "Readable in ambient light AND see-through is a hard combination — note the only things that manage both aren’t image displays at all, but switchable glass (opacity control)." },
+    cheap:    { x: "cost",          y: "availability", fx: true,  fy: false,
+      cap: "Cheap and easy to obtain. Cost is flipped to ▼ so “cheaper is better,” and the frontier hugs the affordable, buy-it-today corner." },
+    surface:  { x: "dimensionality",y: "transparency", fx: false, fy: false,
+      cap: "Images that leave the screen: both volumetric (true 3D) and see-through, so they float free in space rather than living on a surface." }
+  };
+  var FAMILY_COLORS = (function () {
+    var fams = DATA.map(function (r) { return r.family; })
+      .filter(function (v, i, a) { return a.indexOf(v) === i; }).sort();
+    var m = {};
+    fams.forEach(function (f, i) { m[f] = "hsl(" + Math.round((i * 137.508) % 360) + ",62%,58%)"; });
+    return m;
+  })();
+  var tState = { x: "resolution", y: "scale", flipX: false, flipY: false };
+  var tEl = {}, tnsTip = null;
+
+  function axisMeta(key) {
+    var col = colByKey(key);
+    if (col.type === "score") return { col: col, max: 3, ticks: ["0", "1", "2", "3"], label: AXIS_DESC[key] || col.label };
+    var ticks = col.order.map(function (v) { return (CAT_LABELS[key] && CAT_LABELS[key][v]) || v; });
+    return { col: col, max: col.order.length - 1, ticks: ticks, label: AXIS_DESC[key] || col.label };
+  }
+  function numVal(row, key) {
+    var col = colByKey(key);
+    if (col.type === "score") return scoreOf(row, key);
+    var idx = rankCat(row, col); return idx < 0 ? null : idx;
+  }
+  function fmtVal(row, key) {
+    var col = colByKey(key);
+    if (col.type === "score") { var s = scoreOf(row, key); return s === null ? "—" : String(s) + "/3"; }
+    var v = valueOf(row, key); return v ? ((CAT_LABELS[key] && CAT_LABELS[key][v]) || v) : "—";
+  }
+  function rowById(id) { for (var i = 0; i < DATA.length; i++) if (DATA[i].id === id) return DATA[i]; return null; }
+  function goodX(r) { var v = numVal(r, tState.x); return tState.flipX ? axisMeta(tState.x).max - v : v; }
+  function goodY(r) { var v = numVal(r, tState.y); return tState.flipY ? axisMeta(tState.y).max - v : v; }
+  function paretoSet(rows) {
+    return rows.filter(function (r) {
+      return !rows.some(function (o) {
+        if (o === r) return false;
+        return goodX(o) >= goodX(r) && goodY(o) >= goodY(r) && (goodX(o) > goodX(r) || goodY(o) > goodY(r));
+      });
+    });
+  }
+  function strongPhrase(key, flip) {
+    var m = axisMeta(key), tick = m.ticks[flip ? 0 : m.max], lbl = m.label.toLowerCase();
+    return colByKey(key).type === "score" ? (tick + "/" + m.max + " " + lbl) : ("“" + tick + "” " + lbl);
+  }
+
+  function renderTensions() {
+    var x = tState.x, y = tState.y, mx = axisMeta(x), my = axisMeta(y);
+    var W = 760, H = 560, L = 104, Rm = 28, Tm = 34, Bm = 70, pw = W - L - Rm, ph = H - Tm - Bm;
+    var INSET = 30, R0 = 5; // inset the data domain so edge clusters don't spill over the labels
+    var plotted = [], missing = [];
+    DATA.forEach(function (r) {
+      (numVal(r, x) === null || numVal(r, y) === null) ? missing.push(r) : plotted.push(r);
+    });
+    function px(v) { return L + INSET + (mx.max ? v / mx.max : 0) * (pw - 2 * INSET); }
+    function py(v) { return Tm + INSET + (ph - 2 * INSET) - (my.max ? v / my.max : 0) * (ph - 2 * INSET); }
+
+    // cluster points sharing a cell so ties don't fully overlap
+    var groups = {};
+    plotted.forEach(function (r) { var k = numVal(r, x) + "," + numVal(r, y); (groups[k] = groups[k] || []).push(r); });
+    var innerW = pw - 2 * INSET, innerH = ph - 2 * INSET;
+    var spread = Math.min(innerW / (mx.max || 1), innerH / (my.max || 1)) * 0.42, pos = {};
+    var maxHalf = INSET - R0 - 2; // a cluster can never reach past the inset into the axis labels
+    Object.keys(groups).forEach(function (k) {
+      var arr = groups[k].slice().sort(function (a, b) { return a.name < b.name ? -1 : 1; });
+      var parts = k.split(","), bx = px(+parts[0]), by = py(+parts[1]);
+      var n = arr.length, cols = Math.ceil(Math.sqrt(n)), rowsN = Math.ceil(n / cols);
+      var step = Math.min(cols > 1 ? spread / (cols - 1) : spread, 13);
+      if (cols > 1) step = Math.min(step, (2 * maxHalf) / (cols - 1));
+      var ox = (cols - 1) / 2 * step, oy = (rowsN - 1) / 2 * step;
+      arr.forEach(function (r, i) {
+        pos[r.id] = { cx: bx + (i % cols) * step - ox, cy: by + Math.floor(i / cols) * step - oy };
+      });
+    });
+
+    var s = '<svg viewBox="0 0 ' + W + ' ' + H + '" class="tns-svg" preserveAspectRatio="xMidYMid meet">';
+    for (var i = 0; i <= mx.max; i++) {
+      var X = px(i);
+      s += '<line class="grid" x1="' + X + '" y1="' + Tm + '" x2="' + X + '" y2="' + (Tm + ph) + '"/>';
+      s += '<text class="tick" x="' + X + '" y="' + (Tm + ph + 18) + '" text-anchor="middle">' + esc(mx.ticks[i]) + '</text>';
+    }
+    for (var j = 0; j <= my.max; j++) {
+      var Y = py(j);
+      s += '<line class="grid" x1="' + L + '" y1="' + Y + '" x2="' + (L + pw) + '" y2="' + Y + '"/>';
+      s += '<text class="tick" x="' + (L - 9) + '" y="' + (Y + 4) + '" text-anchor="end">' + esc(my.ticks[j]) + '</text>';
+    }
+    s += '<text class="axis-title" x="' + (L + pw / 2) + '" y="' + (H - 10) + '" text-anchor="middle">' +
+         esc(mx.label) + (tState.flipX ? " ▾" : " ▴") + '</text>';
+    s += '<text class="axis-title" transform="translate(16,' + (Tm + ph / 2) + ') rotate(-90)" text-anchor="middle">' +
+         esc(my.label) + (tState.flipY ? " ▾" : " ▴") + '</text>';
+
+    var front = paretoSet(plotted);
+    if (front.length > 1) {
+      var seen = {}, pts = [];
+      front.map(function (r) { return { x: px(numVal(r, x)), y: py(numVal(r, y)) }; })
+        .sort(function (a, b) { return a.x - b.x || a.y - b.y; })
+        .forEach(function (p) { var key = p.x.toFixed(1) + "," + p.y.toFixed(1); if (!seen[key]) { seen[key] = 1; pts.push(key); } });
+      if (pts.length > 1) s += '<polyline class="frontier" points="' + pts.join(" ") + '"/>';
+    }
+    plotted.forEach(function (r) {
+      var p = pos[r.id], col = FAMILY_COLORS[r.family] || "#888", low = r.confidence === "low";
+      s += '<circle class="pt' + (low ? " low" : "") + '" data-id="' + esc(r.id) + '" cx="' + p.cx.toFixed(1) +
+           '" cy="' + p.cy.toFixed(1) + '" r="5" ' +
+           (low ? ('fill="none" stroke="' + col + '" stroke-width="2"') : ('fill="' + col + '" stroke="rgba(0,0,0,.35)"')) + '/>';
+    });
+    s += '</svg>';
+    tEl.plot.innerHTML = s;
+
+    // insight
+    var corner = plotted.filter(function (r) { return goodX(r) === mx.max && goodY(r) === my.max; });
+    var sx = strongPhrase(x, tState.flipX), sy = strongPhrase(y, tState.flipY);
+    if (corner.length === 0) {
+      tEl.insight.innerHTML = '<strong>Empty corner.</strong> Nothing is both ' + sx + ' and ' + sy +
+        ' — that combination is a real gap. The closest options sit on the dashed frontier.';
+    } else {
+      var names = corner.slice(0, 4).map(function (r) { return esc(r.name); }).join(", ") + (corner.length > 4 ? ", …" : "");
+      tEl.insight.innerHTML = '<strong>' + corner.length + (corner.length === 1 ? ' display' : ' displays') +
+        '</strong> reach both ' + sx + ' and ' + sy + ': ' + names + '.';
+    }
+
+    // missing-data note (honest about gaps)
+    if (!missing.length) tEl.missing.textContent = "Plotting all " + plotted.length + " displays on these two axes.";
+    else {
+      var mn = missing.slice(0, 6).map(function (r) { return r.name; }).join(", ") + (missing.length > 6 ? ", …" : "");
+      tEl.missing.innerHTML = "Plotting " + plotted.length + " of " + DATA.length + ". <span class='muted'>" +
+        missing.length + " not shown — no rating on " + esc(mx.label.toLowerCase()) + " or " + esc(my.label.toLowerCase()) + ": " + esc(mn) + "</span>";
+    }
+
+    // legend
+    var fams = plotted.map(function (r) { return r.family; }).filter(function (v, i, a) { return a.indexOf(v) === i; }).sort();
+    var lh = fams.map(function (f) { return '<span class="lg-fam"><span class="sw" style="background:' + FAMILY_COLORS[f] + '"></span>' + esc(f) + '</span>'; }).join("");
+    lh += '<span class="lg-fam"><span class="sw hollow"></span>low-confidence rating</span>';
+    lh += '<span class="lg-fam"><span class="sw line"></span>trade-off frontier</span>';
+    tEl.legend.innerHTML = lh;
+  }
+
+  function initTensions() {
+    tEl.x = document.getElementById("tns-x"); tEl.y = document.getElementById("tns-y");
+    tEl.fx = document.getElementById("tns-fx"); tEl.fy = document.getElementById("tns-fy");
+    tEl.plot = document.getElementById("tns-plot"); tEl.legend = document.getElementById("tns-legend");
+    tEl.insight = document.getElementById("tns-insight"); tEl.missing = document.getElementById("tns-missing");
+    tEl.caption = document.getElementById("tns-caption");
+    function clearCaption() { tEl.caption.hidden = true; tEl.caption.textContent = ""; }
+
+    PLOT_AXES.forEach(function (k) {
+      var label = axisMeta(k).label;
+      [tEl.x, tEl.y].forEach(function (sel) {
+        var o = document.createElement("option"); o.value = k; o.textContent = label; sel.appendChild(o);
+      });
+    });
+    tEl.x.value = tState.x; tEl.y.value = tState.y;
+    tEl.x.addEventListener("change", function () { tState.x = tEl.x.value; clearCaption(); renderTensions(); });
+    tEl.y.addEventListener("change", function () { tState.y = tEl.y.value; clearCaption(); renderTensions(); });
+    tEl.fx.addEventListener("click", function () { tState.flipX = !tState.flipX; tEl.fx.textContent = tState.flipX ? "▼" : "▲"; clearCaption(); renderTensions(); });
+    tEl.fy.addEventListener("click", function () { tState.flipY = !tState.flipY; tEl.fy.textContent = tState.flipY ? "▼" : "▲"; clearCaption(); renderTensions(); });
+
+    Array.prototype.forEach.call(document.querySelectorAll(".preset"), function (b) {
+      b.addEventListener("click", function () {
+        var p = PRESETS[b.getAttribute("data-preset")]; if (!p) return;
+        tState.x = p.x; tState.y = p.y; tState.flipX = p.fx; tState.flipY = p.fy;
+        tEl.x.value = p.x; tEl.y.value = p.y;
+        tEl.fx.textContent = p.fx ? "▼" : "▲"; tEl.fy.textContent = p.fy ? "▼" : "▲";
+        tEl.caption.textContent = p.cap || ""; tEl.caption.hidden = !p.cap;
+        renderTensions();
+      });
+    });
+
+    // shared tooltip
+    tnsTip = document.createElement("div"); tnsTip.className = "tns-tip"; tnsTip.hidden = true;
+    document.body.appendChild(tnsTip);
+    tEl.plot.addEventListener("mouseover", function (e) {
+      var c = e.target; if (!c.classList || !c.classList.contains("pt")) return;
+      var r = rowById(c.getAttribute("data-id")); if (!r) return;
+      tnsTip.innerHTML = "<strong>" + esc(r.name) + "</strong><br><span class='muted'>" + esc(r.family) + "</span><br>" +
+        esc(axisMeta(tState.x).label) + ": " + esc(fmtVal(r, tState.x)) + " · " +
+        esc(axisMeta(tState.y).label) + ": " + esc(fmtVal(r, tState.y));
+      tnsTip.hidden = false;
+    });
+    tEl.plot.addEventListener("mousemove", function (e) {
+      if (tnsTip.hidden) return; tnsTip.style.left = (e.clientX + 13) + "px"; tnsTip.style.top = (e.clientY + 13) + "px";
+    });
+    tEl.plot.addEventListener("mouseout", function (e) {
+      if (e.target.classList && e.target.classList.contains("pt")) tnsTip.hidden = true;
+    });
+    tEl.plot.addEventListener("click", function (e) {
+      var c = e.target; if (c.classList && c.classList.contains("pt")) { var r = rowById(c.getAttribute("data-id")); if (r) showDetail(r); }
+    });
+  }
+
+  function setupViews() {
+    var tabM = document.getElementById("tab-matrix"), tabT = document.getElementById("tab-tensions");
+    var vM = document.getElementById("view-matrix"), vT = document.getElementById("view-tensions");
+    function show(matrix) {
+      vM.hidden = !matrix; vT.hidden = matrix;
+      tabM.classList.toggle("active", matrix); tabT.classList.toggle("active", !matrix);
+      tabM.setAttribute("aria-selected", matrix); tabT.setAttribute("aria-selected", !matrix);
+      if (!matrix) renderTensions();
+    }
+    tabM.addEventListener("click", function () { show(true); });
+    tabT.addEventListener("click", function () { show(false); });
   }
 
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", init);

--- a/comparison-tool/displays.js
+++ b/comparison-tool/displays.js
@@ -309,7 +309,7 @@ window.DISPLAYS = [
       color:          { value: "full", note: "RGB lasers; 7-color low end to wide gamut high end." },
       motion:         { score: 2, note: "Flicker risk if content too complex at 60fps." },
       transparency:   { score: 3, note: "Draws lines in mid-air/haze." },
-      dimensionality: { value: "volumetric", note: "2D outlines; volumetric possible with multiple units/haze." },
+      dimensionality: { value: "flat", note: "Draws 2D vector outlines; in haze the beams read as lines/cones in mid-air, but it isn't a controllable 3D volume." },
       availability:   { value: "buy", note: "Mature niche; vendors supply units and safety variances; licensed operators." },
       cost:           { score: 2, note: "Professional equipment (485mW, 1W, 2W+ classes)." },
       safety:         { score: 0, note: "Severe: 1mW can damage eyes; 5mW+ needs protection; fire/ozone; licensing required." }

--- a/comparison-tool/index.html
+++ b/comparison-tool/index.html
@@ -51,6 +51,12 @@
     </details>
   </header>
 
+  <div class="view-switch" role="tablist" aria-label="Views">
+    <button id="tab-matrix" class="tab active" role="tab" aria-selected="true">▦ Matrix</button>
+    <button id="tab-tensions" class="tab" role="tab" aria-selected="false">⤬ Tensions</button>
+  </div>
+
+  <div id="view-matrix">
   <section class="controls" aria-label="Filters">
     <div class="control">
       <label for="search">Search</label>
@@ -104,6 +110,35 @@
       <thead><tr id="head-row"></tr></thead>
       <tbody id="body"></tbody>
     </table>
+  </div>
+  </div><!-- /view-matrix -->
+
+  <div id="view-tensions" hidden>
+    <div class="tns-controls">
+      <div class="control">
+        <label for="tns-x">Horizontal axis</label>
+        <span class="axis-pick"><select id="tns-x"></select><button id="tns-fx" class="dir" type="button" title="Flip which end the frontier hugs">▲</button></span>
+      </div>
+      <div class="control">
+        <label for="tns-y">Vertical axis</label>
+        <span class="axis-pick"><select id="tns-y"></select><button id="tns-fy" class="dir" type="button" title="Flip which end the frontier hugs">▲</button></span>
+      </div>
+      <div class="tns-presets">
+        <span class="control-label">Try a tension</span>
+        <button class="preset" type="button" data-preset="bigsharp">Big or sharp</button>
+        <button class="preset" type="button" data-preset="bright">Bright &amp; see-through</button>
+        <button class="preset" type="button" data-preset="cheap">Cheap &amp; available</button>
+        <button class="preset" type="button" data-preset="surface">Leaving the surface</button>
+      </div>
+    </div>
+    <p id="tns-insight" class="tns-insight"></p>
+    <p id="tns-caption" class="tns-caption" hidden></p>
+    <div class="tns-stage">
+      <div id="tns-plot" class="tns-plot"></div>
+      <div id="tns-legend" class="tns-legend"></div>
+    </div>
+    <p id="tns-missing" class="tns-missing"></p>
+    <p class="tns-foot muted">A rough, qualitative map — positions come from coarse 0–3 affordance ratings, so points are jittered within each cell and many ties are real. The dashed line is the trade-off frontier (the best you can currently get); the ▲/▼ buttons flip which end counts as "more." Hover a dot for details; click to open its full entry.</p>
   </div>
 
   <aside id="detail" class="detail" hidden></aside>

--- a/comparison-tool/styles.css
+++ b/comparison-tool/styles.css
@@ -157,6 +157,49 @@ tbody tr:focus { outline: 2px solid var(--accent); outline-offset: -2px; }
 .d-source { color: var(--muted); font-size: 12px; }
 code { background: var(--panel-2); padding: 1px 5px; border-radius: 4px; font-size: 12px; }
 
+/* view switch */
+.view-switch { max-width: 1100px; margin: 0 auto 14px; display: flex; gap: 6px; }
+.view-switch .tab {
+  background: var(--panel); color: var(--muted); border: 1px solid var(--line);
+  border-radius: 8px; padding: 8px 16px; font-size: 14px; font-weight: 600; cursor: pointer;
+}
+.view-switch .tab:hover { color: var(--text); border-color: var(--accent); }
+.view-switch .tab.active { color: var(--text); border-color: var(--accent); background: var(--panel-2); box-shadow: inset 0 -2px 0 var(--accent); }
+
+/* tensions view */
+.tns-controls {
+  max-width: 1100px; margin: 0 auto 12px; display: flex; flex-wrap: wrap; gap: 12px 18px; align-items: flex-end;
+  background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 12px 14px;
+}
+.axis-pick { display: flex; gap: 6px; }
+.axis-pick select { background: var(--panel-2); color: var(--text); border: 1px solid var(--line); border-radius: 7px; padding: 6px 8px; font-size: 14px; min-width: 150px; }
+.dir { width: 32px; border: 1px solid var(--line); border-radius: 7px; background: var(--panel-2); color: var(--accent); cursor: pointer; font-size: 13px; }
+.dir:hover { border-color: var(--accent); }
+.tns-presets { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-left: auto; }
+.control-label { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin-right: 2px; }
+.preset { background: transparent; color: var(--accent-2); border: 1px solid var(--line); border-radius: 999px; padding: 5px 11px; font-size: 12.5px; cursor: pointer; }
+.preset:hover { border-color: var(--accent-2); }
+.tns-insight { max-width: 1100px; margin: 0 auto 8px; padding: 8px 12px; background: var(--panel); border: 1px solid var(--line); border-left: 3px solid var(--accent); border-radius: 8px; font-size: 14px; }
+.tns-caption { max-width: 1100px; margin: -2px auto 10px; padding: 0 4px; font-size: 13px; line-height: 1.5; color: var(--muted); }
+.tns-stage { max-width: 1100px; margin: 0 auto; display: flex; gap: 16px; align-items: flex-start; }
+.tns-plot { flex: 1; min-width: 0; background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 6px; }
+.tns-svg { width: 100%; height: auto; display: block; }
+.tns-svg .grid { stroke: var(--line); stroke-width: 1; }
+.tns-svg .tick { fill: var(--muted); font-size: 11px; font-family: inherit; }
+.tns-svg .axis-title { fill: var(--text); font-size: 12.5px; font-weight: 600; font-family: inherit; }
+.tns-svg .frontier { fill: none; stroke: var(--accent-2); stroke-width: 2; stroke-dasharray: 5 4; opacity: .9; }
+.tns-svg .pt { cursor: pointer; }
+.tns-svg .pt:hover { stroke: #fff; stroke-width: 2.5; }
+.tns-legend { width: 190px; flex: none; display: flex; flex-direction: column; gap: 5px; font-size: 12.5px; color: var(--text); }
+.lg-fam { display: flex; align-items: center; gap: 7px; }
+.lg-fam .sw { width: 12px; height: 12px; border-radius: 50%; flex: none; }
+.lg-fam .sw.hollow { background: transparent; border: 2px solid var(--muted); }
+.lg-fam .sw.line { width: 16px; height: 0; border-radius: 0; border-top: 2px dashed var(--accent-2); }
+.tns-missing { max-width: 1100px; margin: 10px auto 0; font-size: 13px; color: var(--text); }
+.tns-foot { max-width: 1100px; margin: 6px auto 0; font-size: 12.5px; }
+.tns-tip { position: fixed; z-index: 50; pointer-events: none; background: var(--panel-2); border: 1px solid var(--accent); border-radius: 8px; padding: 7px 10px; font-size: 12px; color: var(--text); max-width: 240px; box-shadow: 0 6px 20px rgba(0,0,0,.4); }
+@media (max-width: 720px) { .tns-stage { flex-direction: column; } .tns-legend { width: auto; flex-direction: row; flex-wrap: wrap; gap: 10px 16px; } }
+
 /* footer */
 .site-footer { max-width: 1100px; margin: 22px auto 0; color: var(--muted); font-size: 13px; }
 .site-footer a { color: var(--accent); }


### PR DESCRIPTION
Adds a second **Tensions** view (view-switcher) to the comparison tool, sharing `displays.js`.

- Pick any two axes → family-colored scatter; jittered clusters with **capped spread + inset domain** so edge clusters no longer cover the axis labels.
- Dashed **Pareto frontier** + per-axis ▲/▼ flip toggles; auto **insight line** names the empty corner or who reaches it.
- Four preset 'tensions' with plain-language **captions** (e.g. clarifying what 'resolution' means) — the seed of a future Stories layer.
- Honest 'not shown' note for displays lacking a rating on the chosen pair; low-confidence points drawn hollow.
- Data fix: `laser-projector` dimensionality volumetric → flat, correcting the 'leaving the surface' grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)