### PR TITLE
Rename to The Display Atlas + Installation Multitool companion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're on Gitbook, the link to the [Github for this article is here](https://
 If your project or image is featured here and you would prefer me to remove it, please send me a message/email/etc (contact info on [my website](https://www.ablairneal.com)). Additionally, if you have something you think needs to change or be added, please submit a pull request and I'll add it in (or send me an email!).
 
 {% hint style="info" %}
-🧭 **Try the [Display Chooser](https://laserpilot.github.io/Survey_of_Alternative_Displays/comparison-tool/)** — an interactive matrix that compares the displays in this survey by their real-world strengths (daylight readability, scale, transparency, 3D-ness, cost, and more), so you can optimize a choice for a given experience or intention.
+🧭 **Explore [The Display Atlas](https://laserpilot.github.io/Survey_of_Alternative_Displays/comparison-tool/)** — an interactive companion that maps the displays in this survey by their real-world strengths (daylight readability, scale, transparency, 3D-ness, cost, and more) across four lenses: a comparison matrix, a trade-off explorer, a map of "display-space," and guided stories. Pair it with the [Interactive Installation Multitool](https://laserpilot.github.io/interactive-installation-multitool/) for the practical install specs — screen height, sizing, ADA.
 {% endhint %}
 
 ## To add: 2025 and beyond:

--- a/comparison-tool/README.md
+++ b/comparison-tool/README.md
@@ -1,4 +1,4 @@
-# Display Chooser — comparison tool
+# The Display Atlas
 
 A small, dependency-free web tool that turns the *Survey of Alternative Displays* from a
 **taxonomy** (organized by how each display works) into a **decision aid** (organized by what each

--- a/comparison-tool/app.js
+++ b/comparison-tool/app.js
@@ -1,4 +1,4 @@
-/* Display Chooser — render / sort / filter the comparison matrix.
+/* The Display Atlas — render / sort / filter the comparison matrix.
  * No framework, no build step. Reads window.DISPLAYS from displays.js. */
 (function () {
   "use strict";

--- a/comparison-tool/index.html
+++ b/comparison-tool/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Display Chooser — Survey of Alternative Displays</title>
+  <title>The Display Atlas — Survey of Alternative Displays</title>
   <meta name="description" content="A comparison matrix of alternative display technologies, rated on qualitative affordances for art and experience design.">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header class="site-header">
-    <h1>Display Chooser</h1>
+    <h1>The Display Atlas</h1>
     <p class="tagline">
-      A comparison matrix for the
-      <a href="https://blair-neal.gitbook.io/survey-of-alternative-displays/" target="_blank" rel="noopener">Survey of Alternative Displays</a>.
-      Pick what your experience needs; see which technologies fit.
+      Charting the alternative ways to make light — four lenses on the
+      <a href="https://blair-neal.gitbook.io/survey-of-alternative-displays/" target="_blank" rel="noopener">Survey of Alternative Displays</a>:
+      a matrix, a trade-off explorer, a map, and guided stories.
     </p>
     <details class="disclaimer">
       <summary>About these ratings &amp; the affordance scale</summary>
@@ -168,6 +168,10 @@
       Data layer: <code>displays.js</code> · Part of the
       <a href="https://github.com/laserpilot/Survey_of_Alternative_Displays" target="_blank" rel="noopener">Survey of Alternative Displays</a>
       by Blair Neal. Ratings are qualitative and community-correctable.
+    </p>
+    <p>
+      Companion tool: <a href="https://laserpilot.github.io/interactive-installation-multitool/" target="_blank" rel="noopener">Interactive Installation Multitool</a>
+      — once you know <em>which</em> display, work out <em>how</em> to install it (screen height, sizing, ADA, viewing distance).
     </p>
   </footer>
 

--- a/comparison-tool/styles.css
+++ b/comparison-tool/styles.css
@@ -1,4 +1,4 @@
-/* Display Chooser — styles. Plain CSS, no preprocessor. */
+/* The Display Atlas — styles. Plain CSS, no preprocessor. */
 :root {
   --bg: #0f1115;
   --panel: #171a21;

--- a/outline.md
+++ b/outline.md
@@ -5,7 +5,7 @@ description: This is an overview of everything that is covered in the following 
 # Outline
 
 {% hint style="info" %}
-🧭 **New — [Display Chooser](https://laserpilot.github.io/Survey_of_Alternative_Displays/comparison-tool/):** an interactive matrix that compares these technologies by their real-world strengths — daylight readability, scale, transparency, 3D-ness, cost, and availability. Filter by what your experience needs. (Hosted on GitHub Pages; opens outside GitBook.)
+🧭 **New — [The Display Atlas](https://laserpilot.github.io/Survey_of_Alternative_Displays/comparison-tool/):** an interactive way to explore these technologies across four lenses — a comparison matrix, a trade-off explorer, a map of "display-space," and guided stories. A companion [Interactive Installation Multitool](https://laserpilot.github.io/interactive-installation-multitool/) covers the practical install side (screen height, sizing, ADA). (Hosted on GitHub Pages; opens outside GitBook.)
 {% endhint %}
 
 * **Introduction**


### PR DESCRIPTION
Renames the tool from *Display Chooser* to **The Display Atlas** everywhere (title, header, README, source comments, GitBook callouts), refreshes the tagline for the four-lens exploration framing, and adds a companion link to the [Interactive Installation Multitool](https://laserpilot.github.io/interactive-installation-multitool/) in the footer and the GitBook callouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)